### PR TITLE
Update rand to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,8 @@ keywords = ["constant", "constant-time", "crypto", "benchmark"]
 [dependencies]
 clap = "2.25"
 ctrlc = "3.0"
-rand = "0.3"
+rand = "0.6.5"
+rand_chacha = "0.1.1"
 
 [dev-dependencies]
-rand = "0.3"
+rand = "0.6.5"

--- a/examples/ctbench-foo.rs
+++ b/examples/ctbench-foo.rs
@@ -3,7 +3,7 @@ extern crate dudect_bencher;
 extern crate rand;
 
 use dudect_bencher::{BenchRng, Class, CtRunner};
-use rand::Rng;
+use rand::prelude::*;
 
 // Return a random vector of length len
 fn rand_vec(len: usize, rng: &mut BenchRng) -> Vec<u8> {
@@ -72,7 +72,7 @@ fn vec_eq(runner: &mut CtRunner, rng: &mut BenchRng) {
 
 // Expand the main function to include benches for arith and vec_eq
 ctbench_main_with_seeds!(
-    (arith, Some([0x6b6c816d, 0x395d3f8e, 0x798e4828, 0xfbb23c0f])),
+    (arith, Some(0x6b6c816d)),
     (vec_eq, None)
 );
 // Alternatively, for no explicit seeds, you can use

--- a/src/ctbench.rs
+++ b/src/ctbench.rs
@@ -147,7 +147,7 @@ impl ConsoleBenchState {
         self.write_plain(&format!("bench {} ... ", name))
     }
 
-    fn write_seed(&mut self, seed: &u64, name: &BenchName) -> io::Result<()> {
+    fn write_seed(&mut self, seed: u64, name: &BenchName) -> io::Result<()> {
         let name = name.padded(self.max_name_len);
         self.write_plain(&format!("bench {} seeded with [0x{:x}]\n",
                                   name, seed))
@@ -189,7 +189,7 @@ pub fn run_benches_console(opts: BenchOpts, benches: Vec<BenchMetadata>) -> io::
                 let (_, summ) = msg;
                 st.write_result(&summ)
             },
-            BenchEvent::BSeed(ref seed, ref name) => st.write_seed(seed, name),
+            BenchEvent::BSeed(ref seed, ref name) => st.write_seed(*seed, name),
         }
     }
 
@@ -294,7 +294,7 @@ fn run_bench_with_bencher(name: &BenchName, benchfn: &BenchFn, cb: &mut CtBenche
 
     // Write the runtime samples out
     let samples_iter = cb.samples.0.iter().zip(cb.samples.1.iter());
-    cb.file_out.as_mut().map(|mut f| {
+    cb.file_out.as_mut().map(|f| {
         for (x, y) in samples_iter {
             write!(f, "\n{},0,{}", name.0, x).expect("Error writing data to file");
             write!(f, "\n{},0,{}", name.0, y).expect("Error writing data to file");

--- a/src/ctbench.rs
+++ b/src/ctbench.rs
@@ -63,7 +63,7 @@ impl CtBencher {
             samples: (Vec::new(), Vec::new()),
             ctx: None,
             file_out: None,
-            rng: BenchRng::new_unseeded(),
+            rng: BenchRng::seed_from_u64(0u64),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@
 extern crate clap;
 extern crate ctrlc;
 extern crate rand;
+extern crate rand_chacha;
 
 pub mod ctbench;
 mod stats;

--- a/src/toplevel.rs
+++ b/src/toplevel.rs
@@ -52,10 +52,9 @@ macro_rules! ctbench_main_with_seeds {
         fn main() {
             let mut benches = Vec::new();
             $(
-                let seed_vec: Option<Vec<u32>> = $seed.map(|s: [u32; 4]| s.to_vec());
                 benches.push(BenchMetadata {
                     name: BenchName(stringify!($function)),
-                    seed: seed_vec,
+                    seed: $seed,
                     benchfn: $function,
                 });
             )+


### PR DESCRIPTION
Hi there!

I've updated the `rand` dependency to 0.6. `[u32]` was no longer available to seed the RNG, and the other option was to use either `[0u8; 32]`, which I thought might clutter the printed bench results, or `u64` which is what I went with since it seemed more simple.

`rand_chacha` is being pulled in as an extra dependency because the re-export of `rand_chacha` in `rand` is marked as deprecated.