### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Michael Rosenberg", "micro@fastmail.com"]
 name = "dudect-bencher"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2018"
 
 license = "MIT"
@@ -14,10 +14,10 @@ description = "An implementation of the DudeCT constant-time function tester"
 keywords = ["constant", "constant-time", "crypto", "benchmark"]
 
 [dependencies]
-clap = "2.25"
-ctrlc = "3.0"
-rand = "0.6"
-rand_chacha = "0.1"
+clap = "2.33"
+ctrlc = "3.1"
+rand = "0.7"
+rand_chacha = "0.2"
 
 [dev-dependencies]
-rand = "0.6"
+rand = "0.7"


### PR DESCRIPTION
Since MSRV isn't specified in this crate, the bump to 1.32 MSRV coming from the `rand` upgrade does not seem like it constitutes a breaking change and I've therefor bumped `dudect-bencher` to `0.4.1`.  