### PR TITLE
Feature flag to use core::hint::black_box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+Entries are listed in reverse chronological order.
+
+# 0.5.x series
+
+## 0.5.1
+
+* Added `core-hint-black-box` feature, which enables Rust's built-in best-effort black box abstraction for versions >= 1.66.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 authors = ["Michael Rosenberg <michael@mrosenberg.pub>"]
 name = "dudect-bencher"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 
-license = "MIT"
+license = "MIT OR Apache-2.0"
 
 repository = "https://github.com/rozbb/dudect-bencher/"
 documentation = "https://docs.rs/dudect-bencher/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ clap = "2"
 ctrlc = "3"
 rand = "0.8"
 rand_chacha = "0.3"
+
+[features]
+core_hint_black_box = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT OR Apache-2.0"
 
 repository = "https://github.com/rozbb/dudect-bencher/"
 documentation = "https://docs.rs/dudect-bencher/"
+readme = "README.md"
 
 description = "An implementation of the DudeCT constant-time function tester"
 
@@ -20,4 +21,4 @@ rand = "0.8"
 rand_chacha = "0.3"
 
 [features]
-core_hint_black_box = []
+core-hint-black-box = []

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ To run the `vec_eq` benchmark continuously, collecting more samples as it goes a
 To run the benchmarks in `ctbench-foo` and get the raw runtimes in CSV format, run `cargo run
 --release --example ctbench-foo -- --out data.csv`.
 
+Rust versions 1.66 and higher support a new best-effort optimization barrier (`core::hint::black_box`).
+To use the new optimization barrier, enable the `core_hint_black_box` feature.
+
 ## Interpreting Output
 
 The benchmark output looks like

--- a/README.md
+++ b/README.md
@@ -101,19 +101,18 @@ t-values greater than 5 are generally considered a good indication that the func
 
 ## Command line arguments
 
-To run a subset of the benchmarks whose name contains a specific string, use `--filter`. Example:
+* `--filter` runs a subset of the benchmarks whose name contains a specific string. Example:
 ```shell
 cargo run --release --example ctbench-foo -- --filter ar
 ```
 will run only the benchmarks with the substring `ar` in it, i.e., `arith`, and not `vec_eq`.
-
-To run a benchmark continuously, collecting more samples as it goes along, use `--continuous`. Example:
+* `--continuous` run a benchmark continuously, collecting more samples as it goes along. Example:
 ```shell
 cargo run --release --example ctbench-foo -- --continuous vec_eq
 ```
 will run the `vec_eq` benchmark continuously.
 
-To get raw runtimes in CSV format, use `--out`. Example:
+* `--out` outputs raw runtimes in CSV format. Example:
 ```shell
 cargo run --release --example ctbench-foo -- --out data.csv
 ```

--- a/README.md
+++ b/README.md
@@ -2,53 +2,124 @@
 [![Version](https://img.shields.io/crates/v/dudect-bencher.svg)](https://crates.io/crates/dudect-bencher)
 [![Docs](https://docs.rs/dudect-bencher/badge.svg)](https://docs.rs/dudect-bencher)
 
-This crate implements the [DudeCT](https://eprint.iacr.org/2016/1123.pdf) statistical methods for
-testing constant-time functions. It is based loosely off of the
-[`bencher`](https://github.com/bluss/bencher) crate.
+This crate implements the [DudeCT](https://eprint.iacr.org/2016/1123.pdf) statistical methods for testing whether functions are constant-time. It is based loosely off of the [`bencher`](https://github.com/bluss/bencher) benchmarking framework.
 
-## Usage
+In general, it is not possible to prove that a function always runs in constant time. The purpose of this tool is to find non-constant-timeness when it exists. This is not easy, and it requires the user to think very hard about where the non-constant-timeness might be.
 
-Example use is as follows. Since this requires the current crate as a dependency, it is easiest to
-put the benchmarks in `examples/`. Take a look at [`examples/ctbench-foo.rs`](examples/ctbench-foo.rs) for sample source code.
+# Import and features
 
-To run all the benchmarks in `examples/ctbench-foo.rs`, you can simply run `cargo run --release
---example ctbench-foo`.
-
-To run a subset of the benchmarks in the above file that have a the substring `ar` in it, run
-`cargo run --release --example ctbench-foo -- --filter ar`.
-
-To run the `vec_eq` benchmark continuously, collecting more samples as it goes along, run `cargo run
---release --example ctbench-foo -- --continuous vec_eq`.
-
-To run the benchmarks in `ctbench-foo` and get the raw runtimes in CSV format, run `cargo run
---release --example ctbench-foo -- --out data.csv`.
-
-Rust versions 1.66 and higher support a new best-effort optimization barrier (`core::hint::black_box`).
-To use the new optimization barrier, enable the `core_hint_black_box` feature.
-
-## Interpreting Output
-
-The benchmark output looks like
-
+To import this crate, put the following line in your `Cargo.toml`:
+```toml
+dudect-bencher = "0.5"
 ```
+
+Feature flags exposed by this crate:
+
+* `core-hint-black-box` (default) — Enables a new best-effort optimization barrier (`core::hint::black_box`). **This will not compile if you're using a Rust version <1.66.**
+
+# Usage
+
+This framework builds a standalone binary. So you must define a `main.rs`, or a file in your `src/bin` directory, or a separate binary crate that pulls in the library you want to test.
+
+At a high, level you test a function `f` by first defining two sets inputs to `f`, called Right and Left. The way you pick these is highly subjective. You need to already have an idea of what might cause non-constant-time behavior. You then fill in the Left and Right sets such that (you think) `f(l)` and `f(r)` will take a different amount of time to run, on average, where `l` comes from Left and `r` from Right. Finally, you run the benchmarks and label which set is which.
+
+Here is an example of testing the equality function `v == u` where `v` and `u` are `Vec<u8>` of the same length. This is clearly not a constant time function. We define the left distribution to be a set of `(v, u)` where `v == u`, and the right distribution to be the set of `(v, u)` where `v[6] != u[6]`.
+
+```rust
+use dudect_bencher::{ctbench_main, BenchRng, Class, CtRunner};
+use rand::{Rng, RngCore};
+
+// Return a random vector of length len
+fn rand_vec(len: usize, rng: &mut BenchRng) -> Vec<u8> {
+    let mut arr = vec![0u8; len];
+    rng.fill(arr.as_mut_slice());
+    arr
+}
+
+// Benchmark for equality of vectors. This does an early return when it finds an
+// inequality, so it should be very much not constant-time
+fn vec_eq(runner: &mut CtRunner, rng: &mut BenchRng) {
+    // Make vectors of size 100
+    let vlen = 100;
+    let mut inputs: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
+    let mut classes = Vec::new();
+
+    // Make 100,000 random pairs of vectors
+    for _ in 0..100_000 {
+        // Flip a coin. If true, make a pair of vectors that are equal to each
+        // other and put it in the Left distribution
+        if rng.gen::<bool>() {
+            let v1 = rand_vec(vlen, rng);
+            let v2 = v1.clone();
+            inputs.push((v1, v2));
+            classes.push(Class::Left);
+        }
+        // Otherwise, make a pair of vectors that differ at the 6th element and
+        // put it in the right distribution
+        else {
+            let v1 = rand_vec(vlen, rng);
+            let mut v2 = v1.clone();
+            v2[5] = 7;
+            inputs.push((v1, v2));
+            classes.push(Class::Right);
+        }
+    }
+
+    for (class, (u, v)) in classes.into_iter().zip(inputs.into_iter()) {
+        // Now time how long it takes to do a vector comparison
+        runner.run_one(class, || u == v);
+    }
+}
+
+// Crate the main function to include the bench for vec_eq
+ctbench_main!(vec_eq);
+```
+
+This is a portion of the example code in [`examples/ctbench-foo.rs`](examples/). To run the example, run
+
+```shell
+cargo run --release --example ctbench-foo
+```
+
+See more command line arguments [below](#command-line-arguments)
+
+## Bencher output
+
+The program output looks like
+
+```ignore
 bench array_eq ... : n == +0.046M, max t = +61.61472, max tau = +0.28863, (5/tau)^2 = 300
 ```
 
-It is interpreted as follows. Firstly note that the runtime distributions are cropped at different
-percentiles and about 100 t-tests are performed. Of these t-tests, the one that produces the largest
-absolute t-value is printed as `max_t`. The other values printed are
+It is interpreted as follows. Firstly note that the runtime distributions are cropped at different percentiles and about 100 t-tests are performed. Of these t-tests, the one that produces the largest absolute t-value is printed as `max_t`. The other values printed are
 
  * `n`, indicating the number of samples used in computing this t-value
- * `max_tau`, which is the t-value scaled for the samples size (formally, `max_tau = max_t /
-   sqrt(n)`)
- * `(5/tau)^2`, which indicates the number of measurements that would be needed to distinguish the
-   two distributions with t > 5
+ * `max_tau`, which is the t-value scaled for the samples size (formally, `max_tau = max_t / sqrt(n)`)
+ * `(5/tau)^2`, which indicates the number of measurements that would be needed to distinguish the two distributions with t > 5
 
-t-values greater than 5 are generally considered a good indication that the function is not constant
-time. t-values less than 5 does not necessarily imply that the function is constant-time, since
-there may be other input distributions under which the function behaves significantly differently.
+t-values greater than 5 are generally considered a good indication that the function is not constant time. t-values less than 5 does not necessarily imply that the function is constant-time, since there may be other input distributions under which the function behaves significantly differently.
 
-## License
+## Command line arguments
+
+To run a subset of the benchmarks whose name contains a specific string, use `--filter`. Example:
+```shell
+cargo run --release --example ctbench-foo -- --filter ar
+```
+will run only the benchmarks with the substring `ar` in it, i.e., `arith`, and not `vec_eq`.
+
+To run a benchmark continuously, collecting more samples as it goes along, use `--continuous`. Example:
+```shell
+cargo run --release --example ctbench-foo -- --continuous vec_eq
+```
+will run the `vec_eq` benchmark continuously.
+
+To get raw runtimes in CSV format, use `--out`. Example:
+```shell
+cargo run --release --example ctbench-foo -- --out data.csv
+```
+will output all the benchmarks in `ctbench-foo.rs` to `data.csv`.
+
+# License
 
 Licensed under either of
 

--- a/examples/ctbench-foo.rs
+++ b/examples/ctbench-foo.rs
@@ -1,10 +1,10 @@
 use dudect_bencher::{ctbench_main_with_seeds, BenchRng, Class, CtRunner};
-use rand::{Rng, RngCore};
+use rand::Rng;
 
 // Return a random vector of length len
 fn rand_vec(len: usize, rng: &mut BenchRng) -> Vec<u8> {
     let mut arr = vec![0u8; len];
-    rng.fill_bytes(&mut arr);
+    rng.fill(arr.as_mut_slice());
     arr
 }
 

--- a/src/ctbench.rs
+++ b/src/ctbench.rs
@@ -333,12 +333,19 @@ fn filter_benches(filter: &Option<String>, bs: Vec<BenchMetadata>) -> Vec<BenchM
 //
 // A function that is opaque to the optimizer, to allow benchmarks to pretend to use outputs to
 // assist in avoiding dead-code elimination.
+#[cfg(not(feature = "core_hint_black_box"))]
 fn black_box<T>(dummy: T) -> T {
     unsafe {
         let ret = ::std::ptr::read_volatile(&dummy);
         ::std::mem::forget(dummy);
         ret
     }
+}
+
+#[cfg(feature = "core_hint_black_box")]
+#[inline]
+fn black_box<T>(dummy: T) -> T {
+    ::core::hint::black_box(dummy)
 }
 
 /// Specifies the distribution that a particular run belongs to

--- a/src/ctbench.rs
+++ b/src/ctbench.rs
@@ -333,7 +333,7 @@ fn filter_benches(filter: &Option<String>, bs: Vec<BenchMetadata>) -> Vec<BenchM
 //
 // A function that is opaque to the optimizer, to allow benchmarks to pretend to use outputs to
 // assist in avoiding dead-code elimination.
-#[cfg(not(feature = "core_hint_black_box"))]
+#[cfg(not(feature = "core-hint-black-box"))]
 fn black_box<T>(dummy: T) -> T {
     unsafe {
         let ret = ::std::ptr::read_volatile(&dummy);
@@ -342,7 +342,7 @@ fn black_box<T>(dummy: T) -> T {
     }
 }
 
-#[cfg(feature = "core_hint_black_box")]
+#[cfg(feature = "core-hint-black-box")]
 #[inline]
 fn black_box<T>(dummy: T) -> T {
     ::core::hint::black_box(dummy)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,46 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! This crate implements the [DudeCT](https://eprint.iacr.org/2016/1123) statistical methods for
-//! testing constant-time functions. It is based loosely off of the
-//! [`bencher`](https://github.com/bluss/bencher) crate.
-//!
-//! The core idea of the DudeCT test is to construct two sets of inputs for the function in
-//! question `f`. The two sets of inputs will correspond to the `Left` distribution and the `Right`
-//! distribution. The user is expected to select inputs that demonstrate the potential time
-//! discrepency that they are trying to test.
-//!
-//! For example, if `f` tests the equality of two given vectors, the `Left` distribution might
-//! contain random pairs of equal vectors, while the `Right` distribution might contain vectors who
-//! differ at random places or maybe in a fixed place. Once these two input sets are established,
-//! the test is performed and the statistical difference of the distribution of runtimes is
-//! calculated. If the function behaves significantly differently for inputs from `Left` vs
-//! `Right`, the runtime distributions should be significantly different. This difference will be
-//! reflected in the computed t value. See `examples/ctbench-foo.rs` for example code
-//!
-//! The program output looks like
-//!
-//! ```text
-//! bench array_eq ... : n == +0.046M, max t = +61.61472, max tau = +0.28863, (5/tau)^2 = 300
-//! ```
-//!
-//! It is interpreted as follows. Firstly note that the runtime distributions are cropped at
-//! different percentiles and about 100 t-tests are performed. Of these t-tests, the one that
-//! produces the largest absolute t-value is printed as `max_t`. The other values printed are
-//!
-//!  * `n`, indicating the number of samples used in computing this t-value
-//!  * `max_tau`, which is the t-value scaled for the samples size (formally, `max_tau = max_t /
-//!    sqrt(n)`)
-//!  * `(5/tau)^2`, which indicates the number of measurements that would be needed to distinguish
-//!    the two distributions with t > 5
-//!
-//! t-values greater than 5 are generally considered a good indication that the function is not
-//! constant time. t-values less than 5 does not necessarily imply that the function is
-//! constant-time, since there may be other input distributions under which the function behaves
-//! significantly differently.
-//!
-//! Rust versions 1.66 and higher support a new best-effort optimization barrier ([`core::hint::black_box`]).
-//! To use the new optimization barrier, enable the `core_hint_black_box` feature.
+#![doc = include_str!("../README.md")]
 
 // TODO: More comments
 // TODO: Do "higher order preprocessing" from the paper

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,9 @@
 //! constant time. t-values less than 5 does not necessarily imply that the function is
 //! constant-time, since there may be other input distributions under which the function behaves
 //! significantly differently.
+//!
+//! Rust versions 1.66 and higher support a new best-effort optimization barrier ([`core::hint::black_box`]).
+//! To use the new optimization barrier, enable the `core_hint_black_box` feature.
 
 // TODO: More comments
 // TODO: Do "higher order preprocessing" from the paper


### PR DESCRIPTION
This adds a `core_hint_black_box` feature flag to use `core::hint::black_box` as an optimization barrier, which is available in Rust 1.66 and higher. In principle this should be more reliable and have less overhead than the workaround `black_box` implementation that uses a volatile read. (I also added Apache-2.0 to the license field in Cargo.toml, since I noticed this crate is licensed under the Apache-2.0 license but this wasn't reflected in the Cargo.toml license field.)