### PR TITLE
Fix macro hygiene

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,8 @@
 // TODO: Do "higher order preprocessing" from the paper
 
 pub mod ctbench;
-mod macros;
+#[doc(hidden)]
+pub mod macros;
 mod stats;
 
 // Re-export the rand dependency

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -30,9 +30,8 @@
 #[macro_export]
 macro_rules! ctbench_main_with_seeds {
     ($(($function:path, $seed:expr)),+) => {
-        use clap::App;
+        use $crate::macros::__macro_internal::{clap::App, PathBuf};
         use $crate::ctbench::{run_benches_console, BenchName, BenchMetadata, BenchOpts};
-        use std::path::PathBuf;
         fn main() {
             let mut benches = Vec::new();
             $(
@@ -148,6 +147,13 @@ macro_rules! ctbench_main_with_seeds {
 #[macro_export]
 macro_rules! ctbench_main {
     ($($function:path),+) => {
-        ::dudect_bencher::ctbench_main_with_seeds!($(($function, None)),+);
+        use $crate::macros::__macro_internal::Option;
+        $crate::ctbench_main_with_seeds!($(($function, Option::None)),+);
     }
+}
+
+#[doc(hidden)]
+pub mod __macro_internal {
+    pub use ::clap;
+    pub use ::std::{option::Option, path::PathBuf};
 }


### PR DESCRIPTION
This allows `dudect-bencher` to be used without separately adding `clap = "2"` as a dev-dependency, which is currently necessary because of a macro hygiene issue in `ctbench_main_with_seeds!`. (I also fixed a couple more minor macro hygiene issues that could cause unexpected behavior if the macros were used in a scope where the identifiers `std` or `None` were overridden.)