### PR TITLE
Bump `rand` and `rand_chacha` to `0.10`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+    paths-ignore: ["README.md"]
+  pull_request:
+    branches: ["**"]
+    paths-ignore: ["README.md"]
+
+jobs:
+  test:
+    name: Check test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test
+
+  rustfmt:
+    name: Check fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo fmt --all -- --check
+
+  docsrs:
+    name: Check docs-rs build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+      - run: cargo doc --all-features --no-deps
+        env:
+          RUSTDOCFLAGS: "--cfg docsrs -D warnings"
+
+  msrv:
+    name: Check everything compiles with MSRV
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo +nightly install cargo-msrv --no-default-features
+      - run: cargo +nightly msrv --version
+      - run: cargo +nightly msrv verify --all-features
+
+  clippy:
+    name: Check clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+      - run: cargo clippy --all-features -- -D warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 Entries are listed in reverse chronological order.
 
-# 0.6.x series
+## Unreleased
+
+* Bumped MSRV to 1.85
+* Removed `core-hint-black-box` feature flag, since MSRV now covers `core::hint::black_box`
+* Bumped `rand` to v0.10
 
 ## 0.6.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ authors = ["Michael Rosenberg <michael@mrosenberg.pub>"]
 name = "dudect-bencher"
 version = "0.6.0"
 edition = "2021"
+rust-version = "1.85"
 
 license = "MIT OR Apache-2.0"
 
@@ -19,7 +20,3 @@ clap = "2"
 ctrlc = "3"
 rand = "0.10"
 rand_chacha = "0.10"
-
-[features]
-default = ["core-hint-black-box"]
-core-hint-black-box = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ keywords = ["constant", "constant-time", "crypto", "benchmark"]
 [dependencies]
 clap = "2"
 ctrlc = "3"
-rand = "0.8"
-rand_chacha = "0.3"
+rand = "0.10"
+rand_chacha = "0.10"
 
 [features]
 default = ["core-hint-black-box"]

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Here is an example of testing the equality function `v == u` where `v` and `u` a
 
 ```rust
 use dudect_bencher::{ctbench_main, BenchRng, Class, CtRunner};
-use rand::{Rng, RngCore};
+use rand::{Rng, RngExt};
 
 // Return a random vector of length len
 fn rand_vec(len: usize, rng: &mut BenchRng) -> Vec<u8> {
@@ -48,7 +48,7 @@ fn vec_eq(runner: &mut CtRunner, rng: &mut BenchRng) {
     for _ in 0..100_000 {
         // Flip a coin. If true, make a pair of vectors that are equal to each
         // other and put it in the Left distribution
-        if rng.gen::<bool>() {
+        if rng.random::<bool>() {
             let v1 = rand_vec(vlen, rng);
             let v2 = v1.clone();
             inputs.push((v1, v2));

--- a/README.md
+++ b/README.md
@@ -118,6 +118,14 @@ cargo run --release --example ctbench-foo -- --out data.csv
 ```
 will output all the benchmarks in `ctbench-foo.rs` to `data.csv`.
 
+# MSRV
+
+The current minimum supported Rust version (MSRV) is 1.85.0 (2025-02-20).
+
+# Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for a list of changes made throughout past versions.
+
 # License
 
 Licensed under either of

--- a/examples/ctbench-foo.rs
+++ b/examples/ctbench-foo.rs
@@ -15,10 +15,6 @@ fn arith(runner: &mut CtRunner, rng: &mut BenchRng) {
 
     // Make 100,000 inputs on each run
     for _ in 0..100_000 {
-        #[cfg(target_pointer_width = "64")]
-        inputs.push(rng.random::<u64>());
-
-        #[cfg(target_pointer_width = "32")]
         inputs.push(rng.random::<u32>());
 
         // Randomly pick which distribution this example belongs to

--- a/examples/ctbench-foo.rs
+++ b/examples/ctbench-foo.rs
@@ -1,10 +1,10 @@
 use dudect_bencher::{ctbench_main_with_seeds, BenchRng, Class, CtRunner};
-use rand::Rng;
+use rand::{Rng, RngExt};
 
 // Return a random vector of length len
 fn rand_vec(len: usize, rng: &mut BenchRng) -> Vec<u8> {
     let mut arr = vec![0u8; len];
-    rng.fill(arr.as_mut_slice());
+    rng.fill_bytes(arr.as_mut_slice());
     arr
 }
 
@@ -15,9 +15,14 @@ fn arith(runner: &mut CtRunner, rng: &mut BenchRng) {
 
     // Make 100,000 inputs on each run
     for _ in 0..100_000 {
-        inputs.push(rng.gen::<usize>());
+        #[cfg(target_pointer_width = "64")]
+        inputs.push(rng.random::<u64>());
+
+        #[cfg(target_pointer_width = "32")]
+        inputs.push(rng.random::<u32>());
+
         // Randomly pick which distribution this example belongs to
-        if rng.gen::<bool>() {
+        if rng.random::<bool>() {
             classes.push(Class::Left);
         } else {
             classes.push(Class::Right);
@@ -42,7 +47,7 @@ fn vec_eq(runner: &mut CtRunner, rng: &mut BenchRng) {
     for _ in 0..100_000 {
         // Flip a coin. If true, make a pair of vectors that are equal to each other and put it
         // in the Left distribution
-        if rng.gen::<bool>() {
+        if rng.random::<bool>() {
             let v1 = rand_vec(vlen, rng);
             let v2 = v1.clone();
             inputs.push((v1, v2));

--- a/src/ctbench.rs
+++ b/src/ctbench.rs
@@ -93,7 +93,7 @@ impl CtBencher {
 
     /// Returns a random seed
     fn rand_seed() -> u64 {
-        rand::thread_rng().gen()
+        rand::rng().next_u64()
     }
 
     /// Reseeds the internal RNG with the given seed

--- a/src/ctbench.rs
+++ b/src/ctbench.rs
@@ -2,6 +2,7 @@ use crate::stats;
 
 use std::{
     fs::{File, OpenOptions},
+    hint::black_box,
     io::{self, Write},
     iter::repeat,
     path::PathBuf,
@@ -325,27 +326,6 @@ fn filter_benches(filter: &Option<String>, bs: Vec<BenchMetadata>) -> Vec<BenchM
     filtered.sort_by(|b1, b2| b1.name.0.cmp(&b2.name.0));
 
     filtered
-}
-
-// NOTE: We don't have a proper black box in stable Rust. This is a workaround implementation,
-// that may have a too big performance overhead, depending on operation, or it may fail to
-// properly avoid having code optimized out. It is good enough that it is used by default.
-//
-// A function that is opaque to the optimizer, to allow benchmarks to pretend to use outputs to
-// assist in avoiding dead-code elimination.
-#[cfg(not(feature = "core-hint-black-box"))]
-fn black_box<T>(dummy: T) -> T {
-    unsafe {
-        let ret = ::std::ptr::read_volatile(&dummy);
-        ::std::mem::forget(dummy);
-        ret
-    }
-}
-
-#[cfg(feature = "core-hint-black-box")]
-#[inline]
-fn black_box<T>(dummy: T) -> T {
-    ::core::hint::black_box(dummy)
 }
 
 /// Specifies the distribution that a particular run belongs to

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -4,10 +4,10 @@
 /// [`BenchRng`](crate::ctbench::BenchRng) that's passed to each function.
 ///
 /// ```
-/// use dudect_bencher::{ctbench_main_with_seeds, rand::Rng, BenchRng, Class, CtRunner};
+/// use dudect_bencher::{ctbench_main_with_seeds, rand::{Rng, RngExt}, BenchRng, Class, CtRunner};
 ///
 /// fn foo(runner: &mut CtRunner, rng: &mut BenchRng) {
-///     println!("first u64 is {}", rng.gen::<u64>());
+///     println!("first u64 is {}", rng.random::<u64>());
 ///
 ///     // Run something so we don't get a panic
 ///     runner.run_one(Class::Left, || 0);
@@ -15,7 +15,7 @@
 /// }
 ///
 /// fn bar(runner: &mut CtRunner, rng: &mut BenchRng) {
-///     println!("first u64 is {}", rng.gen::<u64>());
+///     println!("first u64 is {}", rng.random::<u64>());
 ///
 ///     // Run something so we don't get a panic
 ///     runner.run_one(Class::Left, || 0);
@@ -74,7 +74,7 @@ macro_rules! ctbench_main_with_seeds {
 /// usage:
 ///
 /// ```
-/// use dudect_bencher::{ctbench_main, rand::{Rng, RngCore}, BenchRng, Class, CtRunner};
+/// use dudect_bencher::{ctbench_main, rand::{Rng, RngExt}, BenchRng, Class, CtRunner};
 ///
 /// // Return a random vector of length len
 /// fn rand_vec(len: usize, rng: &mut BenchRng) -> Vec<u8> {
@@ -90,9 +90,14 @@ macro_rules! ctbench_main_with_seeds {
 ///
 ///     // Make 100,000 inputs on each run
 ///     for _ in 0..100_000 {
-///         inputs.push(rng.gen::<usize>());
+///         #[cfg(target_pointer_width = "64")]
+///         inputs.push(rng.random::<u64>());
+///        
+///         #[cfg(target_pointer_width = "32")]
+///         inputs.push(rng.random::<u32>());
+///         
 ///         // Randomly pick which distribution this example belongs to
-///         if rng.gen::<bool>() {
+///         if rng.random::<bool>() {
 ///             classes.push(Class::Left);
 ///         }
 ///         else {
@@ -118,7 +123,7 @@ macro_rules! ctbench_main_with_seeds {
 ///     for _ in 0..100_000 {
 ///         // Flip a coin. If true, make a pair of vectors that are equal to each other and put
 ///         // it in the Left distribution
-///         if rng.gen::<bool>() {
+///         if rng.random::<bool>() {
 ///             let v1 = rand_vec(vlen, rng);
 ///             let v2 = v1.clone();
 ///             inputs.push((v1, v2));


### PR DESCRIPTION
Bump rand deps.

I couldn't seem to find an immediate and obvious replacement for `.gen::<usize>()` in the newer versions, that is also implemented for `ChaCha20Rng`, so I just did a `#[cfg(target_pointer_width = " ")]` gate instead. Let me know if this is too hacky.